### PR TITLE
Generics improvement

### DIFF
--- a/library/src/main/java/cz/kinst/jakub/viewmodelbinding/ViewInterface.java
+++ b/library/src/main/java/cz/kinst/jakub/viewmodelbinding/ViewInterface.java
@@ -13,10 +13,10 @@ import android.os.Bundle;
  *
  * @param <T> Generated Data Binding layout class
  */
-public interface ViewInterface<T extends ViewDataBinding> {
+public interface ViewInterface<T extends ViewDataBinding, S extends ViewModel> {
 	Context getContext();
 	T getBinding();
 	Activity getActivity();
 	Bundle getBundle();
-	ViewModelBindingConfig getViewModelBindingConfig();
+	ViewModelBindingConfig<S> getViewModelBindingConfig();
 }

--- a/library/src/main/java/cz/kinst/jakub/viewmodelbinding/ViewModel.java
+++ b/library/src/main/java/cz/kinst/jakub/viewmodelbinding/ViewModel.java
@@ -21,7 +21,7 @@ import android.view.View;
  * @param <T> Layout Data Binding class
  */
 public abstract class ViewModel<T extends ViewDataBinding> extends BaseObservable {
-	private ViewInterface<T> mView;
+	private ViewInterface<T, ? extends ViewModel> mView;
 	private String mViewModelId;
 	private Handler mHandler = new Handler();
 	private Thread mUiThread;
@@ -97,7 +97,7 @@ public abstract class ViewModel<T extends ViewDataBinding> extends BaseObservabl
 	 *
 	 * @return currently attached View or null if no View is attached
 	 */
-	public ViewInterface<T> getView() {
+	public ViewInterface<T, ? extends ViewModel> getView() {
 		return mView;
 	}
 
@@ -212,7 +212,7 @@ public abstract class ViewModel<T extends ViewDataBinding> extends BaseObservabl
 	 *
 	 * @param viewInterface View
 	 */
-	protected void bindView(ViewInterface<T> viewInterface) {
+	protected void bindView(ViewInterface<T, ? extends ViewModel> viewInterface) {
 		mView = viewInterface;
 	}
 

--- a/library/src/main/java/cz/kinst/jakub/viewmodelbinding/ViewModelActivity.java
+++ b/library/src/main/java/cz/kinst/jakub/viewmodelbinding/ViewModelActivity.java
@@ -8,7 +8,7 @@ import android.support.annotation.Nullable;
 import android.support.v7.app.AppCompatActivity;
 
 
-public abstract class ViewModelActivity<T extends ViewDataBinding, S extends ViewModel<T>> extends AppCompatActivity implements ViewInterface {
+public abstract class ViewModelActivity<T extends ViewDataBinding, S extends ViewModel<T>> extends AppCompatActivity implements ViewInterface<T, S> {
 	private final ViewModelBindingHelper<S, T> mViewModelBindingHelper = new ViewModelBindingHelper<>();
 
 

--- a/library/src/main/java/cz/kinst/jakub/viewmodelbinding/ViewModelBindingConfig.java
+++ b/library/src/main/java/cz/kinst/jakub/viewmodelbinding/ViewModelBindingConfig.java
@@ -8,11 +8,11 @@ import android.support.annotation.LayoutRes;
  * <p>
  * Config contains layout resource ID, ViewModel class, ViewModel binding variable name
  */
-public class ViewModelBindingConfig {
+public class ViewModelBindingConfig<T extends ViewModel> {
 
 	@LayoutRes
 	int mLayoutResource;
-	Class mViewModelClass;
+	Class<T> mViewModelClass;
 	int mViewModelVariableName;
 
 
@@ -23,7 +23,7 @@ public class ViewModelBindingConfig {
 	 * @param viewModelClass        ViewModel class
 	 * @param viewModelVariableName Data Binding variable name for injecting the ViewModel - use generated id (e.g. BR.mViewModel)
 	 */
-	public ViewModelBindingConfig(@LayoutRes int layoutResource, Class viewModelClass, int viewModelVariableName) {
+	public ViewModelBindingConfig(@LayoutRes int layoutResource, Class<T> viewModelClass, int viewModelVariableName) {
 		mLayoutResource = layoutResource;
 		mViewModelClass = viewModelClass;
 		mViewModelVariableName = viewModelVariableName;
@@ -36,7 +36,7 @@ public class ViewModelBindingConfig {
 	 * @param layoutResource Layout resource ID
 	 * @param viewModelClass ViewModel class
 	 */
-	public ViewModelBindingConfig(@LayoutRes int layoutResource, Class viewModelClass) {
+	public ViewModelBindingConfig(@LayoutRes int layoutResource, Class<T> viewModelClass) {
 		this(layoutResource, viewModelClass, BR.viewModel);
 	}
 
@@ -46,7 +46,7 @@ public class ViewModelBindingConfig {
 	}
 
 
-	public Class getViewModelClass() {
+	public Class<T> getViewModelClass() {
 		return mViewModelClass;
 	}
 

--- a/library/src/main/java/cz/kinst/jakub/viewmodelbinding/ViewModelDialogFragment.java
+++ b/library/src/main/java/cz/kinst/jakub/viewmodelbinding/ViewModelDialogFragment.java
@@ -10,7 +10,7 @@ import android.view.View;
 import android.view.ViewGroup;
 
 
-public abstract class ViewModelDialogFragment<T extends ViewDataBinding, S extends ViewModel> extends DialogFragment implements ViewInterface {
+public abstract class ViewModelDialogFragment<T extends ViewDataBinding, S extends ViewModel> extends DialogFragment implements ViewInterface<T, S> {
 
 	private final ViewModelBindingHelper<S, T> mViewModelBindingHelper = new ViewModelBindingHelper<>();
 

--- a/library/src/main/java/cz/kinst/jakub/viewmodelbinding/ViewModelFragment.java
+++ b/library/src/main/java/cz/kinst/jakub/viewmodelbinding/ViewModelFragment.java
@@ -10,7 +10,7 @@ import android.view.View;
 import android.view.ViewGroup;
 
 
-public abstract class ViewModelFragment<T extends ViewDataBinding, S extends ViewModel> extends Fragment implements ViewInterface {
+public abstract class ViewModelFragment<T extends ViewDataBinding, S extends ViewModel> extends Fragment implements ViewInterface<T, S> {
 
 	private final ViewModelBindingHelper<S, T> mViewModelBindingHelper = new ViewModelBindingHelper<>();
 

--- a/library/src/main/java/cz/kinst/jakub/viewmodelbinding/ViewModelProvider.java
+++ b/library/src/main/java/cz/kinst/jakub/viewmodelbinding/ViewModelProvider.java
@@ -58,20 +58,20 @@ public class ViewModelProvider {
 	 * @param viewModelClass ViewModel class
 	 * @return ViewModel inside a wrapper containing a flag indicating if the instance was created or restored
 	 */
-	@SuppressWarnings("unchecked")
+//	@SuppressWarnings("unchecked")
 	@NonNull
-	public synchronized ViewModelWrapper getViewModel(String viewModelId, @NonNull Class<? extends ViewModel> viewModelClass) {
+	public synchronized <T extends ViewModel> ViewModelWrapper<T> getViewModel(String viewModelId, @NonNull Class<T> viewModelClass) {
 		// try to get the instance from in-memory map
-		ViewModel instance = mViewModels.get(viewModelId);
+		T instance = (T) mViewModels.get(viewModelId);
 		if(instance != null)
-			return new ViewModelWrapper(instance, false);
+			return new ViewModelWrapper<T>(instance, false);
 
 		// if it doesn't exist, use the default constructor to create new instance
 		try {
 			instance = viewModelClass.newInstance();
 			instance.setViewModelId(viewModelId);
 			mViewModels.put(viewModelId, instance);
-			return new ViewModelWrapper(instance, true);
+			return new ViewModelWrapper<T>(instance, true);
 		} catch(Exception ex) {
 			throw new RuntimeException(ex);
 		}
@@ -82,13 +82,13 @@ public class ViewModelProvider {
 	 * Wrapper around ViewModel instance bearing additional information
 	 * such as a flag indicating if the instance was created or restored
 	 */
-	public static class ViewModelWrapper {
+	public static class ViewModelWrapper<V extends ViewModel> {
 		@NonNull
-		private final ViewModel mViewModel;
+		private final V mViewModel;
 		private final boolean mWasCreated;
 
 
-		private ViewModelWrapper(@NonNull ViewModel viewModel, boolean wasCreated) {
+		private ViewModelWrapper(@NonNull V viewModel, boolean wasCreated) {
 			this.mViewModel = viewModel;
 			this.mWasCreated = wasCreated;
 		}
@@ -100,7 +100,7 @@ public class ViewModelProvider {
 		 * @return ViewModel instance
 		 */
 		@NonNull
-		public ViewModel getViewModel() {
+		public V getViewModel() {
 			return mViewModel;
 		}
 

--- a/sample/src/main/java/cz/kinst/jakub/sample/viewmodelbinding/MainActivity.java
+++ b/sample/src/main/java/cz/kinst/jakub/sample/viewmodelbinding/MainActivity.java
@@ -11,8 +11,9 @@ import cz.kinst.jakub.viewmodelbinding.ViewModelBindingConfig;
  */
 public class MainActivity extends ViewModelActivity<ActivityMainBinding, MainViewModel> {
 
+
 	@Override
-	public ViewModelBindingConfig getViewModelBindingConfig() {
-		return new ViewModelBindingConfig(R.layout.activity_main, MainViewModel.class);
+	public ViewModelBindingConfig<MainViewModel> getViewModelBindingConfig() {
+		return new ViewModelBindingConfig<>(R.layout.activity_main, MainViewModel.class);
 	}
 }

--- a/sample/src/main/java/cz/kinst/jakub/sample/viewmodelbinding/SampleDialogFragment.java
+++ b/sample/src/main/java/cz/kinst/jakub/sample/viewmodelbinding/SampleDialogFragment.java
@@ -23,8 +23,8 @@ public class SampleDialogFragment extends ViewModelDialogFragment<DialogSampleBi
 
 
 	@Override
-	public ViewModelBindingConfig getViewModelBindingConfig() {
-		return new ViewModelBindingConfig(R.layout.dialog_sample, SampleDialogViewModel.class);
+	public ViewModelBindingConfig<SampleDialogViewModel> getViewModelBindingConfig() {
+		return new ViewModelBindingConfig<>(R.layout.dialog_sample, SampleDialogViewModel.class);
 	}
 
 


### PR DESCRIPTION
Change log:
- Add generics to ViewModelBindingConfig which prevents clients from returning wrong Class instance
- Add internal generics (ViewModelWrapper, getViewModel method of ViewModelProvider) to prevent mistakes in types in future
- Raise an exception on unsuccessful variable assignment to ViewDataBinding
