### PR TITLE
Add aggregate view models.

### DIFF
--- a/viewmodelbinding/src/main/java/cz/kinst/jakub/viewmodelbinding/AggregateViewModel.java
+++ b/viewmodelbinding/src/main/java/cz/kinst/jakub/viewmodelbinding/AggregateViewModel.java
@@ -1,0 +1,122 @@
+package cz.kinst.jakub.viewmodelbinding;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import android.content.Intent;
+import android.support.annotation.NonNull;
+
+/**
+ * A view model that aggregates and passes messages to contained sub-views.
+ */
+public class AggregateViewModel extends ViewModel {
+
+    @NonNull
+    private final List<SubViewModel> subviewModels = new ArrayList<>();
+
+    /**
+     * Returns an unmodifiable copied list of the subviews. Use the appropriate add or remove methods
+     * to change the list of subviews.
+     * @return a copied, unmodifiable list of subviews
+     */
+    public List<SubViewModel> getSubviews() {
+        return Collections.unmodifiableList(subviewModels);
+    }
+
+    /**
+     * Adds the provided viewmodels to the list of subviews.
+     * @param viewModels the viewmodels to add
+     */
+    public void addSubviews(@NonNull final SubViewModel... viewModels) {
+        subviewModels.addAll(Arrays.asList(viewModels));
+    }
+
+    /**
+     * Removes the provided viewmodels from the view.
+     * @param viewModels the viewmodels to remove
+     */
+    public void removeSubviews(@NonNull final SubViewModel... viewModels) {
+        subviewModels.removeAll(Arrays.asList(viewModels));
+    }
+
+    // region ViewModel
+
+    @Override
+    public void onViewModelCreated() {
+        super.onViewModelCreated();
+        for (final SubViewModel vm : subviewModels) {
+            vm.onViewModelCreated();
+        }
+    }
+
+    @Override
+    public void onViewModelDestroyed() {
+        super.onViewModelDestroyed();
+        for (final SubViewModel vm : subviewModels) {
+            vm.onViewModelDestroyed();
+        }
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        for (final SubViewModel vm : subviewModels) {
+            vm.onResume();
+        }
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        for (final SubViewModel vm : subviewModels) {
+            vm.onPause();
+        }
+    }
+
+    @Override
+    public void onViewDetached(final boolean finalDetachment) {
+        super.onViewDetached(finalDetachment);
+        for (final SubViewModel vm : subviewModels) {
+            vm.onViewDetached(finalDetachment);
+        }
+    }
+
+    @Override
+    public void onViewAttached(final boolean firstAttachment) {
+        super.onViewAttached(firstAttachment);
+        for (final SubViewModel vm : subviewModels) {
+            if (firstAttachment) {
+                vm.bindView(getView());
+            }
+            vm.onViewAttached(firstAttachment);
+        }
+    }
+
+    @Override
+    public void onRequestPermissionsResult(final int requestCode, final String[] permissions, final int[] grantResults) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+        for (final SubViewModel vm : subviewModels) {
+            vm.onRequestPermissionsResult(requestCode, permissions, grantResults);
+        }
+    }
+
+    @Override
+    protected void onActivityResult(final int requestCode, final int resultCode, final Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        for (final SubViewModel vm : subviewModels) {
+            vm.onActivityResult(requestCode, resultCode, data);
+        }
+    }
+
+    @Override
+    protected void bindView(final ViewInterface<?, ? extends cz.kinst.jakub.viewmodelbinding.ViewModel> viewInterface) {
+        super.bindView(viewInterface);
+        for (final SubViewModel vm : subviewModels) {
+            vm.bindView(viewInterface);
+        }
+    }
+
+    // endregion
+
+}

--- a/viewmodelbinding/src/main/java/cz/kinst/jakub/viewmodelbinding/SubViewModel.java
+++ b/viewmodelbinding/src/main/java/cz/kinst/jakub/viewmodelbinding/SubViewModel.java
@@ -1,0 +1,21 @@
+package cz.kinst.jakub.viewmodelbinding;
+
+import android.content.Intent;
+
+/**
+ * A sub-view to be used by the AggregateViewModel. This only exists to make onActivityResult() and bindView() available
+ * to the aggregate to call during setup.
+ */
+public class SubViewModel extends ViewModel {
+
+    @Override
+    public void onActivityResult(final int requestCode, final int resultCode, final Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+    }
+
+    @Override
+    public void bindView(final ViewInterface<?, ? extends cz.kinst.jakub.viewmodelbinding.ViewModel> viewInterface) {
+        super.bindView(viewInterface);
+    }
+
+}


### PR DESCRIPTION
This adds the ability to have viewmodels that contain other viewmodels. In the Android layout files, you might have, say, a (shared) widget that manages phone number entry and validation, and a viewmodel that contains it and manages the validation of the rest of a form. Something like this:

```
<layout>
  <data>
    <variable name="formViewModel" type="com.company.FormViewModel"/>
    <variable name="phoneViewModel" type="com.company.PhoneViewModel"/>
  </data>
  <LinearLayout>
    <!-- Bound components for the form... -->
    <include layout="@layout/phoneentry" app:viewModel="@{phoneViewModel}"/>
  </LinearLayout>
</layout>
```

This PR allows you to create an outer `FormViewModel` that extends `AggregateViewModel` and a shared `PhoneViewModel` that extends `SubViewModel` and is aggreagated within the `FormViewModel`:

```
class FormViewModel extends AggregateViewModel {

  PhoneViewModel phoneViewModel = new PhoneViewModel();

  class FormViewModel() {
    addSubviews(phoneViewModel);
  }
}
```
